### PR TITLE
Ont markov model

### DIFF
--- a/include/ONTAlignmentModel.hpp
+++ b/include/ONTAlignmentModel.hpp
@@ -10,7 +10,7 @@
 
 #include "AlignmentCommon.hpp"
 
-// #include "AtomicMatrix.hpp"
+#include "AtomicMatrix.hpp"
 // #include "tbb/concurrent_vector.h"
 
 
@@ -22,7 +22,7 @@ public:
   static const uint32_t binLen = 100; // XXX: That should be a parameter
 
   ONTAlignmentModel(double alpha, uint32_t readBins = 4);
-  ~ONTAlignmentModel() { }
+  ~ONTAlignmentModel() {   }
 
   /**
    *  For unpaired reads, update the error model to account for errors
@@ -31,14 +31,20 @@ public:
    */
   void update(const UnpairedRead& aln, const UnpairedRead& primaryAln,
               Transcript& ref, double p, double mass);
-
+  //uint32_t getStateIndex(size_t numIndels, size_t numMisMatch, bool homopolymer );
   /**
    * Compute the log-likelihood of the observed unpaired alignment
    * given the current error model. primaryAln contains the first
    * alignment in the alignment group.
    */
   double logLikelihood(const UnpairedRead& aln, const UnpairedRead& primaryAln, Transcript& ref);
-
+  //added for new ONT model
+   struct AlnModelProb {
+    double fg{salmon::math::LOG_1};
+    double bg{salmon::math::LOG_1};
+  };
+  AlnModelProb logLikelihood(bam_seq_t* read, bam_seq_t* primary, Transcript& ref,
+                       std::vector<AtomicMatrix<double>>& mismatchProfile);
   void normalize();
 
   void printModel(std::ostream&);
@@ -69,6 +75,12 @@ private:
   // Separate models are considered for front and back clips
   std::vector<average> frontClipModel_;
   std::vector<average> backClipModel_;
+  
+  void update(bam_seq_t* read, bam_seq_t* primary, Transcript& ref, double p, double mass,
+            std::vector<AtomicMatrix<double>>& mismatchProfile);
+
+  //Transtion probabilitys for Markov Model
+  std::vector<AtomicMatrix<double>> transitionProbs_;
 };
 
 #endif // ERROR_MODEL

--- a/include/ONTAlignmentModel.hpp
+++ b/include/ONTAlignmentModel.hpp
@@ -20,7 +20,7 @@ class ONTAlignmentModel
 public:
   static const uint32_t maxReadLen = 50000; // XXX: That should be a paramater. Read longer than that are binned together
   static const uint32_t binLen = 100; // XXX: That should be a parameter
-
+  
   ONTAlignmentModel(double alpha, uint32_t readBins = 4);
   ~ONTAlignmentModel() {   }
 
@@ -75,11 +75,15 @@ private:
   // Separate models are considered for front and back clips
   std::vector<average> frontClipModel_;
   std::vector<average> backClipModel_;
+
+  //Transcript front and back clip models
+    average transcriptFrontModel_;
+    average transcriptBackModel_;
   
   void update(bam_seq_t* read, bam_seq_t* primary, Transcript& ref, double p, double mass,
             std::vector<AtomicMatrix<double>>& mismatchProfile);
 
-  //Transtion probabilitys for Markov Model
+  //Transtion probabilities for Markov Model
   std::vector<AtomicMatrix<double>> transitionProbs_;
 };
 

--- a/include/ONTAlignmentModel.hpp
+++ b/include/ONTAlignmentModel.hpp
@@ -21,6 +21,15 @@ public:
   static const uint32_t maxReadLen = 50000; // XXX: That should be a paramater. Read longer than that are binned together
   static const uint32_t binLen = 100; // XXX: That should be a parameter
   
+   /**
+    * kmerLength specifies the length of the kmers that each state represents in the Markov Model
+    * stepSize specifies how far we move the kmer window when looking at state transition 
+    * (ie stepSize = kmerLength means no overlap of kmers,stepSize = kmerLength-1 would mean kmers that overlap by 1 etc. ) 
+    * We must have 0 < stepSize <= kmerLength.
+    */
+  static const uint32_t kmerLength = 50;
+  static const uint32_t stepSize = 50;
+ 
   ONTAlignmentModel(double alpha, uint32_t readBins = 4);
   ~ONTAlignmentModel() {   }
 
@@ -31,7 +40,6 @@ public:
    */
   void update(const UnpairedRead& aln, const UnpairedRead& primaryAln,
               Transcript& ref, double p, double mass);
-  //uint32_t getStateIndex(size_t numIndels, size_t numMisMatch, bool homopolymer );
   /**
    * Compute the log-likelihood of the observed unpaired alignment
    * given the current error model. primaryAln contains the first
@@ -66,24 +74,11 @@ private:
     std::atomic<double> sum;
     average() : mass(0.0), sum(0.0) { }
   };
-  // Error model. Probability parameter p of the binomial distribution
-  // B(p,n) for each read in a bin (based on length n).
-  std::vector<average> errorModel_;
-
-  // Clip length model. Geometric distribution with parameter
-  // p. Binned for read size.
-  // Separate models are considered for front and back clips
-  std::vector<average> frontClipModel_;
-  std::vector<average> backClipModel_;
-
-  //Transcript front and back clip models
-    average transcriptFrontModel_;
-    average transcriptBackModel_;
   
   void update(bam_seq_t* read, bam_seq_t* primary, Transcript& ref, double p, double mass,
             std::vector<AtomicMatrix<double>>& mismatchProfile);
 
-  //Transtion probabilities for Markov Model
+  //Transtion probabilities for the mismatch/indel error Markov Model
   std::vector<AtomicMatrix<double>> transitionProbs_;
 };
 

--- a/src/ONTAlignmentModel.cpp
+++ b/src/ONTAlignmentModel.cpp
@@ -14,28 +14,309 @@
 #include "Transcript.hpp"
 #include "UnpairedRead.hpp"
 
+//Calculate number of states based on kmerLength (should probably be moved to the header file)
+static const uint32_t kmerLength = 6;
+static const uint32_t stepSize = 6;
+static const uint32_t numMismatchStates = kmerLength + 1;
+constexpr static uint32_t getStateIndexNoHomopolymer(size_t numIndels, size_t numMisMatch) {
+    return numMismatchStates * numIndels + numMisMatch;
+}
+
+uint32_t numStatesNoHomo = getStateIndexNoHomopolymer(kmerLength, 0)+1; 
+
+uint32_t getStateIndex(size_t numIndels, size_t numMisMatch, bool homopolymer ) {
+     if (homopolymer){
+      return getStateIndexNoHomopolymer(numIndels,numMisMatch) + numStatesNoHomo;
+     }
+     return getStateIndexNoHomopolymer(numIndels,numMisMatch);
+    }
+uint32_t startStateIdx = getStateIndex(kmerLength, 0, true) + 1;
+uint32_t endStateIdx = getStateIndex(kmerLength, 0, true) + 2;
+uint32_t numStatesTotal = getStateIndex(kmerLength, 0, true) + 3;
+
+
 ONTAlignmentModel::ONTAlignmentModel(double alpha, uint32_t readBins)
     : isEnabled_(true)
     , readBins_(readBins)
     , printed(false)
-    , errorModel_(maxReadLen / binLen + 1)
+    , transitionProbs_(readBins)
     , frontClipModel_(maxReadLen / binLen + 1)
     , backClipModel_(maxReadLen / binLen + 1)
-{ }
+{ 
+  for (size_t i = 0; i < readBins; ++i) {
+    transitionProbs_[i] = std::move(AtomicMatrix<double>(
+        numStatesTotal, numStatesTotal, alpha));
+  }
+
+}
+
+
+
+struct Column
+{uint8_t ref_base;
+uint8_t read_base;
+//size_t num_mismatch;
+//size_t num_indel;
+};
+
+bool is_homopolymer(Column chunk[]){
+  size_t counts[4] = {0};
+  size_t numGaps = 0;
+  for (size_t i = 0; i < kmerLength; i++) {
+    size_t symbol = chunk[i].ref_base;
+    if (symbol <= 3){
+     counts[symbol]+=1;
+    }
+    else {
+      numGaps += 1;
+    }
+  }
+  for (size_t i = 0; i < 4; i++){
+    if (counts[i] >= kmerLength - 1){
+      return true;
+    }
+  }
+  return false;
+}
+//Should return the state index based on the kmer and move the end bases to the middle
+uint32_t processChunk(Column chunk[]){
+  size_t numIndels = 0;
+  size_t numMismatch = 0;
+
+  for  (size_t i = 0; i < kmerLength; i++){
+    if (chunk[i].ref_base >3 ||chunk[i].read_base>3 ){
+      numIndels ++; 
+    }
+    else if(chunk[i].ref_base != chunk[i].read_base){
+      numMismatch++;
+    }
+  }
+  uint32_t stateIdx = getStateIndex(numIndels, numMismatch, is_homopolymer(chunk));
+
+  for (size_t i = 0; i < kmerLength-stepSize; i++){
+   chunk[i].ref_base = chunk[i+stepSize].ref_base;
+   chunk[i].read_base = chunk[i+stepSize].read_base;
+  }
+  return stateIdx;
+}
+//Testing functions (numIndels and numMismatch)
+uint32_t numIndels(Column chunk[]){
+  size_t numIndels = 0;
+  size_t numMismatch = 0;
+
+  for  (size_t i = 0; i < kmerLength; i++){
+    if (chunk[i].ref_base >3 ||chunk[i].read_base>3 ){
+      numIndels ++; 
+    }
+    else if(chunk[i].ref_base != chunk[i].read_base){
+      numMismatch++;
+    }
+  }
+  return numIndels;
+}
+uint32_t numMismatch(Column chunk[]){
+  size_t numIndels = 0;
+  size_t numMismatch = 0;
+
+  for  (size_t i = 0; i < kmerLength; i++){
+    if (chunk[i].ref_base >3 ||chunk[i].read_base>3 ){
+      numIndels ++; 
+    }
+    else if(chunk[i].ref_base != chunk[i].read_base){
+      numMismatch++;
+    }
+  }
+  return numMismatch;
+}
+
+std::string chunkString(Column chunk[]){
+  using namespace salmon::stringtools;
+  std::string ref_string = "";
+  std::string read_string = "";
+  
+  for (size_t i = 0;i < kmerLength; i++ ){
+    if(chunk[i].ref_base > 3){
+      ref_string = ref_string +  "-";
+    }
+    else{
+      ref_string = ref_string + twoBitToChar[chunk[i].ref_base];
+    }
+    if(chunk[i].read_base > 3){
+      read_string = read_string +  "-";
+    }
+    else{
+      read_string =  read_string + twoBitToChar[chunk[i].read_base];
+    }
+  }
+ return ("Ref: " + ref_string + " Read: " + read_string );
+}
+
+ONTAlignmentModel::AlnModelProb ONTAlignmentModel::logLikelihood( bam_seq_t* read, bam_seq_t* primary, Transcript& ref,
+std::vector<AtomicMatrix<double>>& transitionProbs){
+  //Implement mm, returns a pair {likelihood, background likelihood}
+   using namespace salmon::stringtools;
+   bool useQual{false};
+   size_t readIdx{0};
+   auto transcriptIdx = bam_pos(read);
+   size_t transcriptLen = ref.RefLength;
+    // if the read starts before the beginning of the transcript,
+    // only consider the part overlapping the transcript
+   if (transcriptIdx < 0) {
+      readIdx = -transcriptIdx;
+      transcriptIdx = 0;
+    }
+  // unsigned version of transcriptIdx
+  size_t uTranscriptIdx = static_cast<size_t>(transcriptIdx);
+
+  if (uTranscriptIdx >= transcriptLen) {
+    std::lock_guard<std::mutex> l(outputMutex_);
+    std::cerr << "transcript index = " << uTranscriptIdx
+              << ", transcript length = " << transcriptLen << "\n";
+    return {salmon::math::LOG_0, salmon::math::LOG_1};
+  }
+
+  // std::stringstream readStream, matchStream, refStream;
+
+  uint32_t* cigar = bam_cigar(read);
+  uint32_t cigarLen = bam_cigar_len(read);
+  
+  const bool usePrimary = bam_seq_len(read) == 0 && primary != nullptr;
+  uint8_t* qseq = reinterpret_cast<uint8_t*>(!usePrimary ? bam_seq(read) : bam_seq(primary));
+  uint8_t* qualStr = reinterpret_cast<uint8_t*>(!usePrimary ? bam_qual(read) : bam_qual(primary));
+  int32_t readLen = !usePrimary ? bam_seq_len(read) : bam_seq_len(primary);
+
+  if (cigarLen == 0 or !cigar) {
+    return {salmon::math::LOG_EPSILON, salmon::math::LOG_1};
+  }
+
+  salmon::stringtools::strand readStrand = salmon::stringtools::strand::forward;
+  // foreground likelihood
+  double logLike = salmon::math::LOG_1;
+  // background likelihood
+  double bgLogLike = salmon::math::LOG_1;
+
+  bool advanceInRead{false};
+  bool advanceInReference{false};
+  uint32_t readPosBin{0};
+  uint32_t cigarIdx{0};
+
+  uint32_t prevStateIdx{startStateIdx};
+  uint32_t curStateIdx{0};
+  double invLen = static_cast<double>(readBins_) / bam_seq_len(read);
+  size_t chunk_idx = 0;
+  size_t overlap = kmerLength - stepSize;
+  Column chunk[kmerLength];
+  for (uint32_t cigarIdx = 0; cigarIdx < cigarLen; ++cigarIdx) {
+
+    /*if (chunk_idx == 0){
+      logger_->warn("new alignment start");
+    }*/
+    uint32_t opLen = cigar[cigarIdx] >> BAM_CIGAR_SHIFT;
+    enum cigar_op op =
+        static_cast<enum cigar_op>(cigar[cigarIdx] & BAM_CIGAR_MASK);
+    size_t curReadBase = (BAM_CONSUME_SEQ(op)) ? samToTwoBit[bam_seqi(qseq, readIdx)] : 0;
+    size_t curRefBase = (BAM_CONSUME_REF(op)) ? samToTwoBit[ref.baseAt(uTranscriptIdx, readStrand)] : 0;
+    advanceInRead = false;
+    advanceInReference = false;
+
+    for (size_t i = 0; i < opLen; ++i) {
+      if (advanceInRead) {
+        // Shouldn't happen!
+        if (readIdx >= static_cast<decltype(readIdx)>(readLen)) {
+          if (logger_) {
+            logger_->warn("(in logLikelihood()) CIGAR string for read [{}] "
+                          "seems inconsistent. It refers to non-existant "
+                          "positions in the read! The use_primary flag is {}.",
+                          bam_name(read), usePrimary);
+            std::stringstream cigarStream;
+            for (size_t j = 0; j < cigarLen; ++j) {
+              uint32_t opLen = cigar[j] >> BAM_CIGAR_SHIFT;
+              enum cigar_op op =
+                  static_cast<enum cigar_op>(cigar[j] & BAM_CIGAR_MASK);
+              cigarStream << opLen << opToChr(op);
+            }
+            //logger_->warn("(in logLikelihood()) CIGAR = {}", cigarStream.str());
+          }
+          return {logLike, bgLogLike};
+        }
+        curReadBase = samToTwoBit[bam_seqi(qseq, readIdx)];
+        readPosBin = static_cast<uint32_t>((readIdx * invLen));
+        advanceInRead = false;
+      }
+      if (advanceInReference) {
+        // Shouldn't happen!
+        if (uTranscriptIdx >= transcriptLen) {
+          if (logger_) {
+            logger_->warn(
+                "(in logLikelihood()) CIGAR string for read [{}] "
+                "seems inconsistent. It refers to non-existant "
+                "positions in the reference! Transcript name "
+                "is {}, length is {}, id is {}. Read things refid is {}",
+                bam_name(read), ref.RefName, transcriptLen, ref.id,
+                bam_ref(read));
+          }
+          return {logLike, bgLogLike};
+        }
+        curRefBase = samToTwoBit[ref.baseAt(uTranscriptIdx, readStrand)];
+        advanceInReference = false;
+      }
+
+      setBasesFromCIGAROp_(
+          op, curRefBase, curReadBase); //, readStream, matchStream, refStream);
+      
+      chunk[chunk_idx].ref_base = curRefBase;
+      chunk[chunk_idx].read_base = curReadBase;
+      //logger_ -> warn("ref base {}, read base {}, seq_i {}", curRefBase, curReadBase, bam_seqi(qseq, readIdx));
+      //chunk[chunk_idx].num_mismatch = chunk_idx <= 0 ? 0 : chunk[chunk_idx-1].num_mismatch;
+      //chunk[chunk_idx].num_indel = chunk_idx <= 0 ? 0 : chunk[chunk_idx-1].num_indel;
+       //Match/mismatch case
+
+       //logger_->warn("chunk index: {}, curRefBase: {} curReadBase: {}",chunk_idx, curRefBase, curReadBase);
+     /*if (BAM_CONSUME_SEQ(op) && BAM_CONSUME_REF(op)) {
+        if(curRefBase != curReadBase){
+          chunk[chunk_idx].num_mismatch += 1;
+        }
+        }
+      //Indel case
+      else {
+        chunk[chunk_idx].num_indel += 1;
+      }*/ 
+      chunk_idx ++;
+      if (chunk_idx >= kmerLength)
+        {
+          chunk_idx = kmerLength-stepSize;
+          //logger_-> warn("Likelihood Chunk: {},  num_indel: {}, num mismatch: {}, is homopolymer: {} ",chunkString(chunk),  numIndels(chunk), numMismatch(chunk), is_homopolymer(chunk));
+          curStateIdx = processChunk(chunk);
+        }
+      double tp = transitionProbs[readPosBin](prevStateIdx, curStateIdx);
+      logLike += tp;
+      bgLogLike += transitionProbs[readPosBin](0, 0);
+      prevStateIdx = curStateIdx;
+      if (BAM_CONSUME_SEQ(op)) {
+        ++readIdx;
+        advanceInRead = true;
+      }
+      if (BAM_CONSUME_REF(op)) {
+        ++uTranscriptIdx;
+        advanceInReference = true;
+      }
+    }
+    //Add the transition probability for ending (was here)
+  }
+  //double tp = transitionProbs[readPosBin](curStateIdx, endStateIdx);
+  //logLike += tp;
+  //bgLogLike += transitionProbs[readPosBin](0, 0);
+  //logger_->warn("( logLike: {} bgLogLike: {}",logLike, bgLogLike);
+
+  return {logLike, bgLogLike};
+}
+
 
 double ONTAlignmentModel::logLikelihood(const UnpairedRead& hit, const UnpairedRead& primary, Transcript& ref) {
   using salmon::math::LOG_0;
   using salmon::math::LOG_1;
   constexpr auto dmin = std::numeric_limits<double>::min();
   constexpr double llMin = 1e-10; // Ignore alignment with likelihood below that number
-
-  // if(!printed) {
-  //   std::unique_lock<std::mutex> lock(outputMutex_, std::try_to_lock);
-  //   if(lock.owns_lock()) {
-  //       printed = true;
-  //       printModel(std::cerr);
-  //     }
-  // }
 
   // If chimeric alignment, doesn't align to this transcript. Return 0
   // probability.
@@ -58,31 +339,29 @@ double ONTAlignmentModel::logLikelihood(const UnpairedRead& hit, const UnpairedR
   const int32_t  errorBin  = std::min(alignLen / binLen, (uint32_t)errorModel_.size() - 1);
   const int32_t  frontClipBin   = std::min(cigarRLen / binLen, (uint32_t)frontClipModel_.size() - 1);
   const int32_t  backClipBin    = std::min(cigarRLen / binLen, (uint32_t)backClipModel_.size() - 1);
-  const auto&    errorAvg  = errorModel_[errorBin];
   const auto&    frontClipAvg   = frontClipModel_[frontClipBin];
   const auto&    backClipAvg    = backClipModel_[backClipBin];
 
   double errorllh = LOG_1, frontClipllh = LOG_1, backClipllh = LOG_1; // Error and clip Log Likelihood (front and back)
 
-  if(errorAvg.mass > dmin && frontClipAvg.mass > dmin && backClipAvg.mass > dmin) {
-    // Binomial / Geometric distribution probability of an event (an
-    // error in the sequence, whether a mismatch of indel).
-    const double errorP = errorAvg.sum / errorAvg.mass;
-
-    // Likelihood, based on average mass of errors to get a read
-    // further away from mode (as number of errors).
-    using boost::math::binomial;
-    binomial      errorDist(alignLen, errorP);
-    const int32_t errorMedian     = median(errorDist);
-    const int32_t offMedian       = std::abs(errorMedian - counts.ims());
-    const double  errorLikelihood =  cdf(errorDist, std::max(errorMedian - offMedian, (int32_t)0)) +
-      1.0 - cdf(complement(errorDist, std::min(errorMedian + offMedian, (int32_t)alignLen)));
-    errorllh = errorLikelihood < llMin ? LOG_0 : std::log(errorLikelihood);
-  } else { // Falls into a bin that is empty after training
-    if(logger_)
-      logger_->warn("read {} (length {} - align length {}) has no trained error model",
-                    bam_name(hit.read), cigarRLen, alignLen);
+  //Use transition probs to determine error log likelihood
+  double logLike = salmon::math::LOG_1;
+  double bg = salmon::math::LOG_1;
+  if (BOOST_UNLIKELY(!isEnabled_)) {
+    return logLike;
   }
+  bam_seq_t* read = hit.read;
+  size_t readLen = static_cast<size_t>(bam_seq_len(read));
+  auto alnLogProb = logLikelihood(read, primary.read, ref, transitionProbs_);
+  logLike += alnLogProb.fg;
+  bg += alnLogProb.bg;
+
+  if (logLike == salmon::math::LOG_0) {
+    std::lock_guard<std::mutex> lock(outputMutex_);
+    std::cerr << "error log likelihood: " << logLike << "\n";
+  }
+
+  errorllh = logLike - bg;
 
   // Likelihood to have so many bases soft clipped based on the
   // average error rate. Don't penalize for having fewer clipped bases
@@ -122,9 +401,164 @@ double ONTAlignmentModel::logLikelihood(const UnpairedRead& hit, const UnpairedR
       logger_->warn("read {} (length {}) has no trained clipping model",
                     bam_name(hit.read), cigarRLen);
   }
-
+//logger_->warn("( errorllh: {} frontClipllh: {} backClipllh: {}  ",errorllh, frontClipllh,backClipllh );
   return errorllh + frontClipllh + backClipllh;
 }
+
+void ONTAlignmentModel::update(
+    bam_seq_t* read, bam_seq_t* primary,
+    Transcript& ref, double p, double mass,
+    std::vector<AtomicMatrix<double>>& transitionProbs) {
+       using namespace salmon::stringtools;
+
+   bool useQual{false};
+   size_t readIdx{0};
+   auto transcriptIdx = bam_pos(read);
+   size_t transcriptLen = ref.RefLength;
+    // if the read starts before the beginning of the transcript,
+    // only consider the part overlapping the transcript
+   if (transcriptIdx < 0) {
+      readIdx = -transcriptIdx;
+      transcriptIdx = 0;
+    }
+  // unsigned version of transcriptIdx
+  size_t uTranscriptIdx = static_cast<size_t>(transcriptIdx);
+
+  if (uTranscriptIdx >= transcriptLen) {
+    std::lock_guard<std::mutex> l(outputMutex_);
+    std::cerr << "transcript index = " << uTranscriptIdx
+              << ", transcript length = " << transcriptLen << "\n";
+    return;
+  }
+
+  // std::stringstream readStream, matchStream, refStream;
+
+  uint32_t* cigar = bam_cigar(read);
+  uint32_t cigarLen = bam_cigar_len(read);
+  const bool usePrimary = bam_seq_len(read) == 0 && primary != nullptr;
+  uint8_t* qseq = reinterpret_cast<uint8_t*>(!usePrimary ? bam_seq(read) : bam_seq(primary));
+  uint8_t* qualStr = reinterpret_cast<uint8_t*>(!usePrimary ? bam_qual(read) : bam_qual(primary));
+  int32_t readLen = !usePrimary ? bam_seq_len(read) : bam_seq_len(primary);
+  
+  if (cigarLen == 0 or !cigar) {
+    return ;
+  }
+
+  salmon::stringtools::strand readStrand = salmon::stringtools::strand::forward;
+  bool advanceInRead{false};
+  bool advanceInReference{false};
+  uint32_t readPosBin{0};
+  uint32_t cigarIdx{0};
+
+  uint32_t prevStateIdx{startStateIdx};
+  uint32_t curStateIdx{0};
+  double invLen = static_cast<double>(readBins_) / bam_seq_len(read);
+  size_t chunk_idx = 0;
+  size_t chunk_size = kmerLength;
+  size_t overlap = kmerLength - stepSize;
+  Column chunk[chunk_size];
+
+  for (uint32_t cigarIdx = 0; cigarIdx < cigarLen; ++cigarIdx) {
+    /*if (chunk_idx == 0){
+      logger_->warn("new alignment start");
+    }*/ 
+    uint32_t opLen = cigar[cigarIdx] >> BAM_CIGAR_SHIFT;
+    enum cigar_op op =
+        static_cast<enum cigar_op>(cigar[cigarIdx] & BAM_CIGAR_MASK);
+    size_t curReadBase = (BAM_CONSUME_SEQ(op)) ? samToTwoBit[bam_seqi(qseq, readIdx)] : 0;
+    size_t curRefBase = (BAM_CONSUME_REF(op)) ? samToTwoBit[ref.baseAt(uTranscriptIdx, readStrand)] : 0;
+    advanceInRead = false;
+    advanceInReference = false;
+
+    for (size_t i = 0; i < opLen; ++i) {
+      if (advanceInRead) {
+        // Shouldn't happen!
+        if (readIdx >= static_cast<decltype(readIdx)>(readLen)) {
+          if (logger_) {
+            logger_->warn("(in update()) CIGAR string for read [{}] "
+                          "seems inconsistent. It refers to non-existant "
+                          "positions in the read! Use primary flag is {}",
+                          bam_name(read), usePrimary);
+            std::stringstream cigarStream;
+            for (size_t j = 0; j < cigarLen; ++j) {
+              uint32_t opLen = cigar[j] >> BAM_CIGAR_SHIFT;
+              enum cigar_op op =
+                  static_cast<enum cigar_op>(cigar[j] & BAM_CIGAR_MASK);
+              cigarStream << opLen << opToChr(op);
+            }
+            //logger_->warn("(in update()) CIGAR = {}", cigarStream.str());
+          }
+          return;
+        }
+        curReadBase = samToTwoBit[bam_seqi(qseq, readIdx)];
+        readPosBin = static_cast<uint32_t>((readIdx * invLen));
+        advanceInRead = false;
+      }
+      if (advanceInReference) {
+        // Shouldn't happen!
+        if (uTranscriptIdx >= transcriptLen) {
+          if (logger_) {
+            logger_->warn(
+                "(in update()) CIGAR string for read [{}] "
+                "seems inconsistent. It refers to non-existant "
+                "positions in the reference! Transcript name "
+                "is {}, length is {}, id is {}. Read things refid is {}",
+                bam_name(read), ref.RefName, transcriptLen, ref.id,
+                bam_ref(read));
+          }
+          return;
+        }
+        curRefBase = samToTwoBit[ref.baseAt(uTranscriptIdx, readStrand)];
+        advanceInReference = false;
+      }
+
+      setBasesFromCIGAROp_(
+          op, curRefBase, curReadBase); //, readStream, matchStream, refStream);
+      
+     // logger_->warn("chunk index: {}, curRefBase: {} curReadBase: {}",chunk_idx, curRefBase, curReadBase);
+
+      chunk[chunk_idx].ref_base = curRefBase;
+      chunk[chunk_idx].read_base = curReadBase;
+     
+      //chunk[chunk_idx].num_mismatch = chunk_idx == 0 ? 0 : chunk[chunk_idx-1].num_mismatch;
+      //chunk[chunk_idx].num_indel = chunk_idx == 0 ? 0 : chunk[chunk_idx-1].num_indel;
+       //Match/mismatch case
+      /*if (BAM_CONSUME_SEQ(op) && BAM_CONSUME_REF(op)) {
+        if(curRefBase != curReadBase){
+          chunk[chunk_idx].num_mismatch += 1;
+        }
+        }
+      //Indel case
+      else {
+        chunk[chunk_idx].num_indel += 1;
+      }*/
+      chunk_idx ++;
+      if (chunk_idx >= kmerLength)
+        {
+             
+        //logger_-> warn("Update Chunk: {},  num_indel: {}, num mismatch: {}, homopolymer: {} ",chunkString(chunk),  numIndels(chunk), numMismatch(chunk), is_homopolymer(chunk));
+          curStateIdx = processChunk(chunk);
+          //logger_->warn("Log Likelihood Current State Index: ",curStateIdx, "out of: ",  numStatesTotal);
+          chunk_idx = kmerLength-stepSize;
+        }
+      
+      transitionProbs[readPosBin].increment(prevStateIdx, curStateIdx,mass + p);
+      prevStateIdx = curStateIdx;
+      if (BAM_CONSUME_SEQ(op)) {
+        ++readIdx;
+        advanceInRead = true;
+      }
+      if (BAM_CONSUME_REF(op)) {
+        ++uTranscriptIdx;
+        advanceInReference = true;
+      }
+    }
+    //Add the transition probability for ending
+    curStateIdx = endStateIdx;
+    transitionProbs[readPosBin].increment(prevStateIdx, curStateIdx,mass + p);
+  }
+  return ;
+  }
 
 // Update the probability model. The reads are binned based on their
 // length (the length after soft clipping). For each bin, we assume a
@@ -135,6 +569,8 @@ double ONTAlignmentModel::logLikelihood(const UnpairedRead& hit, const UnpairedR
 // this point: indels and mutations).
 void ONTAlignmentModel::update(const UnpairedRead& hit, const UnpairedRead& primary,
                                Transcript& ref, double p, double mass) {
+    //logger_->warn("in update()");
+
   if (mass == salmon::math::LOG_0) {
     return;
   }
@@ -170,10 +606,7 @@ void ONTAlignmentModel::update(const UnpairedRead& hit, const UnpairedRead& prim
   }
 
   const double newMass = mass;
-  { int32_t binIndex = std::min(alignLen / binLen, (uint32_t)errorModel_.size() - 1);
-    auto& bin = errorModel_[binIndex];
-    salmon::utils::incLoop(bin.mass, newMass);
-    salmon::utils::incLoop(bin.sum, newMass * errorRate);
+  { update(hit.read, primary.read, ref, p, mass, transitionProbs_);
   }
 
   // Update front clip model


### PR DESCRIPTION
Updated error model for ONT reads -- uses a markov model to model mismatches, indels, and homopolymer regions. Kmer size and step size for the markov model are set at 50 in ONTAlignmentModel.hpp, but could be adjusted (50 was found to be the best out of the values of k I tried).